### PR TITLE
remove loop over apt items

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,9 +11,8 @@
 
 - name: install dependencies
   apt:
-    name: "{{ item }}"
+    name: "{{ duplicity_dependencies }}"
     state: "{{ apt_install_state | default('latest') }}"
-  with_items: "{{ duplicity_dependencies }}"
   tags:
     - configuration
     - duplicity
@@ -21,9 +20,8 @@
 
 - name: install
   apt:
-    name: "{{ item }}"
+    name: "{{ duplicity_install }}"
     state: "{{ apt_install_state | default('latest') }}"
-  with_items: "{{ duplicity_install }}"
   tags:
     - configuration
     - duplicity


### PR DESCRIPTION
fixes ansible deprecation warning:
```python
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name: '{{ duplicity_dependencies }}'`
and remove the loop. This feature will be removed in version 2.11.
```